### PR TITLE
feat: Watcher abstract factory skeleton

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add here all the directory of submodules
 add_subdirectory(TrafficManager)
 add_subdirectory(VideoStreamer)
+add_subdirectory(WatcherSpawner)
 
 add_executable(${EXECUTABLE_NAME} main.cpp)
 

--- a/src/TrafficManager/CMakeLists.txt
+++ b/src/TrafficManager/CMakeLists.txt
@@ -4,8 +4,9 @@ target_include_directories(
   TrafficManager
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
          ${CMAKE_CURRENT_SOURCE_DIR}/../VideoStreamer
-         ${CMAKE_CURRENT_SOURCE_DIR}/../VideoStreamer/TransformPerspective)
+         ${CMAKE_CURRENT_SOURCE_DIR}/../VideoStreamer/TransformPerspective
+         ${CMAKE_CURRENT_SOURCE_DIR}/../WatcherSpawner)
 
 target_link_libraries(
   TrafficManager PRIVATE VideoStreamer CalibrateVideoStreamer
-                         TransformPerspective)
+                         TransformPerspective WatcherSpawner)

--- a/src/TrafficManager/TrafficManager.cpp
+++ b/src/TrafficManager/TrafficManager.cpp
@@ -3,6 +3,7 @@
 #include "TrimPerspective.h"
 #include "VideoStreamer.h"
 #include "WarpPerspective.h"
+#include "WatcherSpawner.h"
 #include <iostream>
 #include <opencv2/opencv.hpp>
 
@@ -25,15 +26,63 @@ void TrafficManager::start()
 
     if(calibMode)
     {
-        calibrateStreamPoints();
+        testGuiFactory();
     }
     if(debugMode)
     {
-        // This is blocking! change this later
-        spawnCarObserverDebug();
+        testHeadlessFactory();
     }
 
     std::cout << "TrafficManager ended.\n";
+}
+
+void TrafficManager::testGuiFactory()
+{
+    WatcherSpawner spawner;
+
+    Watcher* vehicleWatcherGui = spawner.spawnWatcher(
+        WatcherType::VEHICLE, RenderMode::GUI, "VehicleStream", "VehicleCalib");
+
+    Watcher* pedestrianWatcherGui =
+        spawner.spawnWatcher(WatcherType::PEDESTRIAN,
+                             RenderMode::GUI,
+                             "PedestrianStream",
+                             "PedestrianCalib");
+
+    Watcher* calibrateWatcherGui = spawner.spawnWatcher(WatcherType::CALIBRATE,
+                                                        RenderMode::GUI,
+                                                        "CalibrateStream",
+                                                        "CalibrateCalib");
+
+    delete vehicleWatcherGui;
+    delete pedestrianWatcherGui;
+    delete calibrateWatcherGui;
+}
+
+void TrafficManager::testHeadlessFactory()
+{
+    WatcherSpawner spawner;
+
+    Watcher* vehicleWatcherHeadless = spawner.spawnWatcher(WatcherType::VEHICLE,
+                                                           RenderMode::HEADLESS,
+                                                           "VehicleStream",
+                                                           "VehicleCalib");
+
+    Watcher* pedestrianWatcherHeadless =
+        spawner.spawnWatcher(WatcherType::PEDESTRIAN,
+                             RenderMode::HEADLESS,
+                             "PedestrianStream",
+                             "PedestrianCalib");
+
+    Watcher* calibrateWatcherHeadless =
+        spawner.spawnWatcher(WatcherType::CALIBRATE,
+                             RenderMode::HEADLESS,
+                             "CalibrateStream",
+                             "CalibrateCalib");
+
+    delete vehicleWatcherHeadless;
+    delete pedestrianWatcherHeadless;
+    delete calibrateWatcherHeadless;
 }
 
 void TrafficManager::calibrateStreamPoints()

--- a/src/TrafficManager/TrafficManager.h
+++ b/src/TrafficManager/TrafficManager.h
@@ -10,6 +10,8 @@ public:
 
     void start();
 
+    void testGuiFactory();
+    void testHeadlessFactory();
     void calibrateStreamPoints();
     void spawnCarObserverDebug();
 

--- a/src/WatcherSpawner/CMakeLists.txt
+++ b/src/WatcherSpawner/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_subdirectory(WatcherFactory)
+
+add_library(WatcherSpawner WatcherSpawner.cpp)
+
+target_include_directories(
+  WatcherSpawner
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/WatcherFactory
+         ${CMAKE_CURRENT_SOURCE_DIR}/WatcherFactory/include
+         ${CMAKE_CURRENT_SOURCE_DIR}/WatcherFactory/VehicleWatcher
+         ${CMAKE_CURRENT_SOURCE_DIR}/WatcherFactory/PedestrianWatcher
+         ${CMAKE_CURRENT_SOURCE_DIR}/WatcherFactory/CalibrateWatcher)
+
+target_link_libraries(WatcherSpawner PRIVATE WatcherFactory)

--- a/src/WatcherSpawner/WatcherFactory/CMakeLists.txt
+++ b/src/WatcherSpawner/WatcherFactory/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_subdirectory(VehicleWatcher)
+add_subdirectory(PedestrianWatcher)
+add_subdirectory(CalibrateWatcher)
+
+add_library(WatcherFactory WatcherFactory.cpp)
+
+target_include_directories(
+  WatcherFactory
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/VehicleWatcher
+         ${CMAKE_CURRENT_SOURCE_DIR}/PedestrianWatcher
+         ${CMAKE_CURRENT_SOURCE_DIR}/CalibrateWatcher)
+
+target_link_libraries(WatcherFactory PRIVATE VehicleWatcher PedestrianWatcher
+                                             CalibrateWatcher)

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CMakeLists.txt
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(CalibrateWatcher CalibrateWatcher.cpp CalibrateGui.cpp
+                             CalibrateHeadless.cpp)
+
+target_include_directories(CalibrateWatcher
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateGui.cpp
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateGui.cpp
@@ -1,0 +1,10 @@
+#include "CalibrateGui.h"
+#include <iostream>
+
+void CalibrateGui::display(const std::string& streamName,
+                           const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Calibrate Gui\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateGui.h
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateGui.h
@@ -1,0 +1,13 @@
+#ifndef CALIBRATE_GUI_H
+#define CALIBRATE_GUI_H
+
+#include "Gui.h"
+
+class CalibrateGui : public Gui
+{
+public:
+    void display(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateHeadless.cpp
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateHeadless.cpp
@@ -1,0 +1,10 @@
+#include "CalibrateHeadless.h"
+#include <iostream>
+
+void CalibrateHeadless::process(const std::string& streamName,
+                                const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Calibrate Headless\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateHeadless.h
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateHeadless.h
@@ -1,0 +1,13 @@
+#ifndef CALIBRATE_HEADLESS_H
+#define CALIBRATE_HEADLESS_H
+
+#include "Headless.h"
+
+class CalibrateHeadless : public Headless
+{
+public:
+    void process(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateWatcher.cpp
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateWatcher.cpp
@@ -1,0 +1,21 @@
+#include "CalibrateWatcher.h"
+#include "CalibrateGui.h"
+#include "CalibrateHeadless.h"
+
+void CalibrateWatcher::spawn(RenderMode mode,
+                             const std::string& streamName,
+                             const std::string& calibName) const
+{
+    if(mode == RenderMode::GUI)
+    {
+        Gui* gui = new CalibrateGui();
+        gui->display(streamName, calibName);
+        delete gui;
+    }
+    else if(mode == RenderMode::HEADLESS)
+    {
+        Headless* headless = new CalibrateHeadless();
+        headless->process(streamName, calibName);
+        delete headless;
+    }
+}

--- a/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateWatcher.h
+++ b/src/WatcherSpawner/WatcherFactory/CalibrateWatcher/CalibrateWatcher.h
@@ -1,0 +1,14 @@
+#ifndef CALIBRATE_WATCHER_H
+#define CALIBRATE_WATCHER_H
+
+#include "Watcher.h"
+
+class CalibrateWatcher : public Watcher
+{
+public:
+    void spawn(RenderMode mode,
+               const std::string& streamName,
+               const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/CMakeLists.txt
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(PedestrianWatcher PedestrianWatcher.cpp PedestrianGui.cpp
+                              PedestrianHeadless.cpp)
+
+target_include_directories(PedestrianWatcher
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianGui.cpp
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianGui.cpp
@@ -1,0 +1,10 @@
+#include "PedestrianGui.h"
+#include <iostream>
+
+void PedestrianGui::display(const std::string& streamName,
+                            const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Pedestrian Gui\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianGui.h
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianGui.h
@@ -1,0 +1,13 @@
+#ifndef PEDESTRIAN_GUI_H
+#define PEDESTRIAN_GUI_H
+
+#include "Gui.h"
+
+class PedestrianGui : public Gui
+{
+public:
+    void display(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianHeadless.cpp
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianHeadless.cpp
@@ -1,0 +1,10 @@
+#include "PedestrianHeadless.h"
+#include <iostream>
+
+void PedestrianHeadless::process(const std::string& streamName,
+                                 const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Pedestrian Headless\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianHeadless.h
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianHeadless.h
@@ -1,0 +1,13 @@
+#ifndef PEDESTRIAN_HEADLESS_H
+#define PEDESTRIAN_HEADLESS_H
+
+#include "Headless.h"
+
+class PedestrianHeadless : public Headless
+{
+public:
+    void process(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianWatcher.cpp
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianWatcher.cpp
@@ -1,0 +1,21 @@
+#include "PedestrianWatcher.h"
+#include "PedestrianGui.h"
+#include "PedestrianHeadless.h"
+
+void PedestrianWatcher::spawn(RenderMode mode,
+                              const std::string& streamName,
+                              const std::string& calibName) const
+{
+    if(mode == RenderMode::GUI)
+    {
+        Gui* gui = new PedestrianGui();
+        gui->display(streamName, calibName);
+        delete gui;
+    }
+    else if(mode == RenderMode::HEADLESS)
+    {
+        Headless* headless = new PedestrianHeadless();
+        headless->process(streamName, calibName);
+        delete headless;
+    }
+}

--- a/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianWatcher.h
+++ b/src/WatcherSpawner/WatcherFactory/PedestrianWatcher/PedestrianWatcher.h
@@ -1,0 +1,14 @@
+#ifndef PEDESTRIAN_WATCHER_H
+#define PEDESTRIAN_WATCHER_H
+
+#include "Watcher.h"
+
+class PedestrianWatcher : public Watcher
+{
+public:
+    void spawn(RenderMode mode,
+               const std::string& streamName,
+               const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/CMakeLists.txt
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(VehicleWatcher VehicleWatcher.cpp VehicleGui.cpp
+                           VehicleHeadless.cpp)
+
+target_include_directories(VehicleWatcher
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleGui.cpp
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleGui.cpp
@@ -1,0 +1,10 @@
+#include "VehicleGui.h"
+#include <iostream>
+
+void VehicleGui::display(const std::string& streamName,
+                         const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Vehicle Gui\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleGui.h
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleGui.h
@@ -1,0 +1,13 @@
+#ifndef VEHICLE_GUI_H
+#define VEHICLE_GUI_H
+
+#include "Gui.h"
+
+class VehicleGui : public Gui
+{
+public:
+    void display(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleHeadless.cpp
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleHeadless.cpp
@@ -1,0 +1,10 @@
+#include "VehicleHeadless.h"
+#include <iostream>
+
+void VehicleHeadless::process(const std::string& streamName,
+                              const std::string& calibName) const
+{
+    std::cout << "Stream Name: " << streamName << std::endl;
+    std::cout << "Calibration Name: " << calibName << std::endl;
+    std::cerr << "No implementation yet for Vehicle Headless\n";
+}

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleHeadless.h
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleHeadless.h
@@ -1,0 +1,13 @@
+#ifndef VEHICLE_HEADLESS_H
+#define VEHICLE_HEADLESS_H
+
+#include "Headless.h"
+
+class VehicleHeadless : public Headless
+{
+public:
+    void process(const std::string& streamName,
+                 const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleWatcher.cpp
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleWatcher.cpp
@@ -1,0 +1,21 @@
+#include "VehicleWatcher.h"
+#include "VehicleGui.h"
+#include "VehicleHeadless.h"
+
+void VehicleWatcher::spawn(RenderMode mode,
+                           const std::string& streamName,
+                           const std::string& calibName) const
+{
+    if(mode == RenderMode::GUI)
+    {
+        Gui* gui = new VehicleGui();
+        gui->display(streamName, calibName);
+        delete gui;
+    }
+    else if(mode == RenderMode::HEADLESS)
+    {
+        Headless* headless = new VehicleHeadless();
+        headless->process(streamName, calibName);
+        delete headless;
+    }
+}

--- a/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleWatcher.h
+++ b/src/WatcherSpawner/WatcherFactory/VehicleWatcher/VehicleWatcher.h
@@ -1,0 +1,14 @@
+#ifndef VEHICLE_WATCHER_H
+#define VEHICLE_WATCHER_H
+
+#include "Watcher.h"
+
+class VehicleWatcher : public Watcher
+{
+public:
+    void spawn(RenderMode mode,
+               const std::string& streamName,
+               const std::string& calibName) const override;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/WatcherFactory.cpp
+++ b/src/WatcherSpawner/WatcherFactory/WatcherFactory.cpp
@@ -1,0 +1,16 @@
+#include "WatcherFactory.h"
+
+Watcher* WatcherFactory::createWatcher(WatcherType type)
+{
+    switch(type)
+    {
+    case WatcherType::VEHICLE:
+        return new VehicleWatcher();
+    case WatcherType::PEDESTRIAN:
+        return new PedestrianWatcher();
+    case WatcherType::CALIBRATE:
+        return new CalibrateWatcher();
+    default:
+        return nullptr; // Invalid type
+    }
+}

--- a/src/WatcherSpawner/WatcherFactory/WatcherFactory.h
+++ b/src/WatcherSpawner/WatcherFactory/WatcherFactory.h
@@ -1,0 +1,21 @@
+#ifndef WATCHER_FACTORY_H
+#define WATCHER_FACTORY_H
+
+#include "CalibrateWatcher.h"
+#include "PedestrianWatcher.h"
+#include "VehicleWatcher.h"
+
+enum class WatcherType
+{
+    VEHICLE,
+    PEDESTRIAN,
+    CALIBRATE
+};
+
+class WatcherFactory
+{
+public:
+    static Watcher* createWatcher(WatcherType type);
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/include/Gui.h
+++ b/src/WatcherSpawner/WatcherFactory/include/Gui.h
@@ -1,0 +1,13 @@
+#ifndef GUI_H
+#define GUI_H
+
+#include <string>
+
+class Gui
+{
+public:
+    virtual void display(const std::string& streamName,
+                         const std::string& calibName) const = 0;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/include/Headless.h
+++ b/src/WatcherSpawner/WatcherFactory/include/Headless.h
@@ -1,0 +1,13 @@
+#ifndef HEADLESS_H
+#define HEADLESS_H
+
+#include <string>
+
+class Headless
+{
+public:
+    virtual void process(const std::string& streamName,
+                         const std::string& calibName) const = 0;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherFactory/include/Watcher.h
+++ b/src/WatcherSpawner/WatcherFactory/include/Watcher.h
@@ -1,0 +1,20 @@
+#ifndef WATCHER_H
+#define WATCHER_H
+
+#include <string>
+
+enum class RenderMode
+{
+    GUI,
+    HEADLESS
+};
+
+class Watcher
+{
+public:
+    virtual void spawn(RenderMode mode,
+                       const std::string& streamName,
+                       const std::string& calibName) const = 0;
+};
+
+#endif

--- a/src/WatcherSpawner/WatcherSpawner.cpp
+++ b/src/WatcherSpawner/WatcherSpawner.cpp
@@ -1,0 +1,16 @@
+#include "WatcherSpawner.h"
+
+Watcher* WatcherSpawner::spawnWatcher(WatcherType type,
+                                      RenderMode mode,
+                                      const std::string& streamName,
+                                      const std::string& calibName)
+{
+    Watcher* watcher = WatcherFactory::createWatcher(type);
+
+    if(watcher)
+    {
+        watcher->spawn(mode, streamName, calibName);
+    }
+
+    return watcher;
+}

--- a/src/WatcherSpawner/WatcherSpawner.h
+++ b/src/WatcherSpawner/WatcherSpawner.h
@@ -1,0 +1,15 @@
+#ifndef WATCHER_SPAWNER_H
+#define WATCHER_SPAWNER_H
+
+#include "WatcherFactory.h"
+
+class WatcherSpawner
+{
+public:
+    static Watcher* spawnWatcher(WatcherType type,
+                                 RenderMode mode,
+                                 const std::string& streamName,
+                                 const std::string& calibName);
+};
+
+#endif


### PR DESCRIPTION
Finished the skeleton of an abstract factory pattern, but this is hidden in the client side. The client only sees the WatcherSpawner. To use this, instantiate a spawner and let it create objects of watcher type and render mode. It also needs the video stream name and calib points filename.